### PR TITLE
Remember landscaping area visibility between sessions (#81)

### DIFF
--- a/scripts/ModSettings.lua
+++ b/scripts/ModSettings.lua
@@ -39,6 +39,7 @@ local defaultExcludeFillTypes = {
 
 ---@class ModSettings
 ---@field materials string[]
+---@field areaVisibility table<string, boolean>
 ---@field defaultEnabled boolean
 ---@field enabled boolean
 ---@field hudEnabled boolean
@@ -57,6 +58,7 @@ function ModSettings.new()
     local self = setmetatable({}, ModSettings_mt)
 
     self.materials = {}
+    self.areaVisibility = {}
     self.defaultEnabled = true
     self.enabled = true
     self.hudEnabled = true
@@ -150,6 +152,34 @@ end
 ---@nodiscard
 function ModSettings:getMaterials()
     return self.materials
+end
+
+---@param uniqueId string
+---@return boolean
+---@nodiscard
+function ModSettings:getAreaVisibility(uniqueId)
+    local visible = self.areaVisibility[uniqueId]
+
+    return visible == nil or visible
+end
+
+---@param uniqueId string
+---@param visible boolean
+function ModSettings:setAreaVisibility(uniqueId, visible)
+    if g_client ~= nil and uniqueId ~= nil and self.areaVisibility[uniqueId] ~= visible then
+        self.areaVisibility[uniqueId] = visible
+
+        self:saveUserSettings()
+    end
+end
+
+---@param uniqueId string
+function ModSettings:deleteAreaVisibility(uniqueId)
+    if g_client ~= nil and uniqueId ~= nil and self.areaVisibility[uniqueId] ~= nil then
+        self.areaVisibility[uniqueId] = nil
+
+        self:saveUserSettings()
+    end
 end
 
 ---@return string?
@@ -248,6 +278,8 @@ end
 
 function ModSettings:loadUserSettings()
     if g_client ~= nil then
+        self.areaVisibility = {}
+
         ---@type XMLFile?
         local xmlFile = XMLFile.loadIfExists('userSettings', ModSettings.XML_FILENAME_USER_SETTINGS)
 
@@ -275,6 +307,15 @@ function ModSettings:loadUserSettings()
 
             g_landscapingManager:setBorderMode(borderMode, true)
 
+            for _, key in xmlFile:iterator('userSettings.areaVisibility.area') do
+                local uniqueId = xmlFile:getString(key .. '#uniqueId')
+                local visible = xmlFile:getBool(key .. '#visible')
+
+                if uniqueId ~= nil and visible ~= nil then
+                    self.areaVisibility[uniqueId] = visible
+                end
+            end
+
             xmlFile:delete()
         end
     end
@@ -297,6 +338,21 @@ function ModSettings:saveUserSettings()
 
             local borderModeStr = LandscapingManager.BORDER_MODE_STR[g_landscapingManager.borderMode] or LandscapingManager.BORDER_MODE_STR[BorderMode.GROUND_MESH_XRAY]
             xmlFile:setString('userSettings.borderMode', borderModeStr)
+
+            local uniqueIds = {}
+
+            for uniqueId, _ in pairs(self.areaVisibility) do
+                table.insert(uniqueIds, uniqueId)
+            end
+
+            table.sort(uniqueIds)
+
+            for i, uniqueId in ipairs(uniqueIds) do
+                local key = string.format('userSettings.areaVisibility.area(%i)', i - 1)
+
+                xmlFile:setString(key .. '#uniqueId', uniqueId)
+                xmlFile:setBool(key .. '#visible', self.areaVisibility[uniqueId])
+            end
 
             xmlFile:save()
             xmlFile:delete()

--- a/scripts/landscaping/LandscapingArea.lua
+++ b/scripts/landscaping/LandscapingArea.lua
@@ -229,6 +229,7 @@ function LandscapingArea:setIsVisible(visible)
         self.visible = visible
 
         g_landscapingManager:updateAreaBorderVisibility(self)
+        g_modSettings:setAreaVisibility(self.uniqueId, visible)
     end
 end
 

--- a/scripts/landscaping/LandscapingManager.lua
+++ b/scripts/landscaping/LandscapingManager.lua
@@ -523,6 +523,8 @@ function LandscapingManager:registerArea(area, noEventSend)
         self.areas[uniqueId] = area
 
         if g_client ~= nil then
+            area.visible = g_modSettings:getAreaVisibility(uniqueId)
+
             local rootNode = createTransformGroup('areaBorderRootNode')
             link(self.borderRootNode, rootNode)
             self.areaBorderRootNode[uniqueId] = rootNode
@@ -545,10 +547,14 @@ function LandscapingManager:deleteAreaByUniqueId(uniqueId, noEventSend)
 
         self.areas[uniqueId] = nil
 
-        if g_client ~= nil and self.areaBorderRootNode[uniqueId] ~= nil then
-            delete(self.areaBorderRootNode[uniqueId])
-            self.areaBorderRootNode[uniqueId] = nil
-            self.areaBorderNodes[uniqueId] = nil
+        if g_client ~= nil then
+            g_modSettings:deleteAreaVisibility(uniqueId)
+
+            if self.areaBorderRootNode[uniqueId] ~= nil then
+                delete(self.areaBorderRootNode[uniqueId])
+                self.areaBorderRootNode[uniqueId] = nil
+                self.areaBorderNodes[uniqueId] = nil
+            end
         end
 
         g_messageCenter:publish(ModMessageType.LANDSCAPING_AREA_DELETE, uniqueId)


### PR DESCRIPTION
## Related issue



## Summary

- store each landscaping area’s client-local visibility by `uniqueId` in `userSettings.xml`
- restore the saved preference whenever an area is registered, including areas registered after the initial map load
- save visibility changes immediately
- remove a stored preference only when its corresponding area is explicitly deleted
- default new or unknown areas to visible

## Implementation

- `ModSettings` loads and saves `userSettings.areaVisibility.area(?)` entries in deterministic `uniqueId` order
- `LandscapingManager` applies the saved preference before creating and updating an area’s border
- `LandscapingArea` persists a visibility change when the player toggles it
- dedicated-server paths are prevented from creating or changing client user settings

Visibility remains client-local. No savegame XML, network stream, protocol, GUI layout, localization, or release-version changes are included.

## Validation

- protected three-launch test using the licensed FS25 client and a fresh test profile:
  - started visible, changed to hidden, and persisted `false`
  - restarted and restored hidden, then changed to visible and persisted `true`
  - restarted and restored visible, then explicitly deleted the area and confirmed its stored preference was removed
  - no relevant game-log issues were detected during any launch
- all protected profile, installed-mod, settings, and shader-cache data was restored byte-for-byte after testing
- focused Lua regression harness: 21 checks passed, covering:
  - missing and malformed settings
  - true/false persistence round trips
  - deterministic XML output
  - late area registration
  - explicit deletion
  - client and listen-server roles
  - dedicated-server write suppression
- all three changed Lua files parse successfully with Lua 5.1
- all 50 shipped XML files parse successfully
- temporary runtime ZIP based on the official 1.6.3.0 release passed archive-integrity and source-equality checks
- `git diff --check` passes

Repository-wide stock Lua 5.1 parsing is not available as a baseline gate because three unchanged upstream files use GIANTS Lua extensions such as `continue` and compound assignment.

