### PR TITLE
Validate permissions for multiplayer events

### DIFF
--- a/scripts/ModUtils.lua
+++ b/scripts/ModUtils.lua
@@ -97,6 +97,56 @@ function ModUtils.getPlayerHasPermission(permission, connection, farmId)
     return false
 end
 
+---@param connection Connection?
+---@param permission string
+---@param farmId? number
+---@return boolean
+---@nodiscard
+function ModUtils.getEventConnectionHasPermission(connection, permission, farmId)
+    if connection == nil then
+        return false
+    end
+
+    if connection:getIsServer() then
+        return true
+    end
+
+    return ModUtils.getPlayerHasPermission(permission, connection, farmId)
+end
+
+---@param connection Connection?
+---@return boolean
+---@nodiscard
+function ModUtils.getEventConnectionIsAdministrator(connection)
+    if connection == nil then
+        return false
+    end
+
+    if connection:getIsServer() then
+        return true
+    end
+
+    if g_currentMission ~= nil and g_currentMission.userManager ~= nil then
+        local user = g_currentMission.userManager:getUserByConnection(connection)
+        return user ~= nil and user:getIsMasterUser()
+    end
+
+    return false
+end
+
+---@param connection Connection?
+---@param permission string
+---@param vehicle Machine?
+---@return boolean
+---@nodiscard
+function ModUtils.getEventConnectionHasVehiclePermission(connection, permission, vehicle)
+    if vehicle == nil or vehicle.getOwnerFarmId == nil then
+        return false
+    end
+
+    return ModUtils.getEventConnectionHasPermission(connection, permission, vehicle:getOwnerFarmId())
+end
+
 ---@param x number
 ---@param y number
 ---@param z number

--- a/scripts/events/SetDefaultEnabledEvent.lua
+++ b/scripts/events/SetDefaultEnabledEvent.lua
@@ -41,6 +41,10 @@ end
 
 ---@param connection Connection
 function SetDefaultEnabledEvent:run(connection)
+    if not ModUtils.getEventConnectionIsAdministrator(connection) then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection)
     end

--- a/scripts/events/SetEnabledEvent.lua
+++ b/scripts/events/SetEnabledEvent.lua
@@ -40,6 +40,10 @@ end
 
 ---@param connection Connection
 function SetEnabledEvent:run(connection)
+    if not ModUtils.getEventConnectionIsAdministrator(connection) then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection)
     end

--- a/scripts/events/SetMaterialsEvent.lua
+++ b/scripts/events/SetMaterialsEvent.lua
@@ -1,6 +1,8 @@
 ---@class SetMaterialsEvent : Event
 ---@field materials string[]
 SetMaterialsEvent = {}
+SetMaterialsEvent.SEND_NUM_BITS_MATERIALS = 10
+SetMaterialsEvent.MAX_NUM_MATERIALS = 2 ^ SetMaterialsEvent.SEND_NUM_BITS_MATERIALS - 1
 
 local SetMaterialsEvent_mt = Class(SetMaterialsEvent, Event)
 
@@ -25,23 +27,22 @@ function SetMaterialsEvent.new(materials)
 end
 
 function SetMaterialsEvent:writeStream(streamId, connection)
-    streamWriteInt32(streamId, #self.materials)
+    local numMaterials = math.min(#self.materials, SetMaterialsEvent.MAX_NUM_MATERIALS)
+    streamWriteUIntN(streamId, numMaterials, SetMaterialsEvent.SEND_NUM_BITS_MATERIALS)
 
-    for _, name in ipairs(self.materials) do
-        streamWriteString(streamId, name)
+    for i = 1, numMaterials do
+        streamWriteString(streamId, self.materials[i])
     end
 end
 
 function SetMaterialsEvent:readStream(streamId, connection)
-    local numMaterials = streamReadInt32(streamId)
+    local numMaterials = streamReadUIntN(streamId, SetMaterialsEvent.SEND_NUM_BITS_MATERIALS)
 
     self.materials = {}
 
-    if numMaterials > 0 then
-        for i = 1, numMaterials do
-            local name = streamReadString(streamId)
-            table.insert(self.materials, name)
-        end
+    for _ = 1, numMaterials do
+        local name = streamReadString(streamId)
+        table.insert(self.materials, name)
     end
 
     self:run(connection)
@@ -49,6 +50,10 @@ end
 
 ---@param connection Connection
 function SetMaterialsEvent:run(connection)
+    if not ModUtils.getEventConnectionIsAdministrator(connection) then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection)
     end

--- a/scripts/events/SetResourcesEvent.lua
+++ b/scripts/events/SetResourcesEvent.lua
@@ -45,6 +45,10 @@ end
 
 ---@param connection Connection
 function SetResourcesEvent:run(connection)
+    if not ModUtils.getEventConnectionIsAdministrator(connection) then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection)
     end

--- a/scripts/gui/InGameMenuTerraFarmFrame.lua
+++ b/scripts/gui/InGameMenuTerraFarmFrame.lua
@@ -401,11 +401,11 @@ function InGameMenuTerraFarmFrame:updateMenuButtons()
                 self.toggleEnabledButtonInfo.text = InGameMenuTerraFarmFrame.L10N_SYMBOL.ACTION_ENABLE
             end
 
-            if ModUtils.getPlayerHasPermission('manageRights') then
+            if ModUtils.getPlayerHasPermission('manageRights', nil, vehicle:getOwnerFarmId()) then
                 table.insert(self.menuButtonInfo, self.toggleEnabledButtonInfo)
             end
 
-            if ModUtils.getPlayerHasPermission('landscaping') then
+            if ModUtils.getPlayerHasPermission('landscaping', nil, vehicle:getOwnerFarmId()) then
                 table.insert(self.menuButtonInfo, self.machineSettingsButtonInfo)
             end
         end
@@ -424,9 +424,8 @@ function InGameMenuTerraFarmFrame:updateMenuButtons()
                 self.toggleActiveButtonInfo.text = Editor.L10N_SYMBOL.SET_VISIBLE
             end
 
-            table.insert(self.menuButtonInfo, self.toggleActiveButtonInfo)
-
             if ModUtils.getPlayerHasPermission('landscaping') then
+                table.insert(self.menuButtonInfo, self.toggleActiveButtonInfo)
                 table.insert(self.menuButtonInfo, self.deleteAreaButtonInfo)
                 self.deleteAreaButtonInfo.text = Editor.L10N_SYMBOL.DELETE
                 table.insert(self.menuButtonInfo, self.editAreaButtonInfo)
@@ -514,7 +513,7 @@ end
 function InGameMenuTerraFarmFrame:onClickMachineSettings()
     local vehicle = self:getSelectedVehicle()
 
-    if vehicle ~= nil then
+    if vehicle ~= nil and ModUtils.getPlayerHasPermission('landscaping', nil, vehicle:getOwnerFarmId()) then
         g_machineScreen:show(vehicle)
     end
 end
@@ -522,13 +521,17 @@ end
 function InGameMenuTerraFarmFrame:onClickToggleEnabled()
     local vehicle = self:getSelectedVehicle()
 
-    if vehicle ~= nil then
+    if vehicle ~= nil and ModUtils.getPlayerHasPermission('manageRights', nil, vehicle:getOwnerFarmId()) then
         vehicle:setMachineEnabled(not vehicle:getMachineEnabled())
         self:updateVehicles()
     end
 end
 
 function InGameMenuTerraFarmFrame:onClickEditArea()
+    if not ModUtils.getPlayerHasPermission('landscaping') then
+        return
+    end
+
     local subCategoryIndex = self.subCategoryPaging:getState()
 
     if subCategoryIndex == 2 then
@@ -547,6 +550,10 @@ function InGameMenuTerraFarmFrame:onClickEditArea()
 end
 
 function InGameMenuTerraFarmFrame:onClickCreateArea()
+    if not ModUtils.getPlayerHasPermission('landscaping') then
+        return
+    end
+
     local subCategoryIndex = self.subCategoryPaging:getState()
 
     if subCategoryIndex == 2 then
@@ -566,6 +573,10 @@ function InGameMenuTerraFarmFrame:onClickCreateArea()
 end
 
 function InGameMenuTerraFarmFrame:onClickDeleteArea()
+    if not ModUtils.getPlayerHasPermission('landscaping') then
+        return
+    end
+
     local subCategoryIndex = self.subCategoryPaging:getState()
 
     if subCategoryIndex == 2 then
@@ -606,6 +617,10 @@ function InGameMenuTerraFarmFrame:onClickDeleteArea()
 end
 
 function InGameMenuTerraFarmFrame:onClickToggleActive()
+    if not ModUtils.getPlayerHasPermission('landscaping') then
+        return
+    end
+
     local subCategoryIndex = self.subCategoryPaging:getState()
 
     if subCategoryIndex == 2 then

--- a/scripts/landscaping/LandscapingManager.lua
+++ b/scripts/landscaping/LandscapingManager.lua
@@ -107,6 +107,10 @@ LandscapingManager.DEFAULT_TERRAIN_LAYERS = {
     'DIRT',
     'GRAVEL'
 }
+LandscapingManager.AREA_CLASSES = {
+    [LandscapingAreaPath.CLASS_NAME] = LandscapingAreaPath,
+    [LandscapingAreaPolygon.CLASS_NAME] = LandscapingAreaPolygon,
+}
 
 LandscapingManager.BORDER_COLOR = { 0.3, 0.3, 0.3, 0.5 }
 LandscapingManager.BORDER_DECAL_COLOR = { 0.3, 0.3, 0.3, 0.85 }
@@ -491,7 +495,7 @@ end
 ---@nodiscard
 function LandscapingManager:createArea(className, uniqueId)
     if self:getCanCreateArea() then
-        local class = _G[className]
+        local class = LandscapingManager.AREA_CLASSES[className]
 
         if class ~= nil then
             ---@type LandscapingArea

--- a/scripts/landscaping/events/AreaDeleteEvent.lua
+++ b/scripts/landscaping/events/AreaDeleteEvent.lua
@@ -41,6 +41,10 @@ end
 
 ---@param connection Connection
 function AreaDeleteEvent:run(connection)
+    if not ModUtils.getEventConnectionHasPermission(connection, 'landscaping') then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection)
     end

--- a/scripts/landscaping/events/AreaRegisterEvent.lua
+++ b/scripts/landscaping/events/AreaRegisterEvent.lua
@@ -42,13 +42,21 @@ function AreaRegisterEvent:readStream(streamId, connection)
 
     ---@diagnostic disable-next-line: assign-type-mismatch
     self.area = g_landscapingManager:createArea(className, uniqueId)
-    self.area:readStream(streamId, connection)
 
-    self:run(connection)
+    if self.area ~= nil then
+        self.area:readStream(streamId, connection)
+        self:run(connection)
+    else
+        Logging.error('AreaRegisterEvent:readStream() Could not create area class "%s"', tostring(className))
+    end
 end
 
 ---@param connection Connection
 function AreaRegisterEvent:run(connection)
+    if not ModUtils.getEventConnectionHasPermission(connection, 'landscaping') then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection)
     end

--- a/scripts/landscaping/events/AreaUpdateEvent.lua
+++ b/scripts/landscaping/events/AreaUpdateEvent.lua
@@ -38,9 +38,10 @@ end
 function AreaUpdateEvent:readStream(streamId, connection)
     local uniqueId = streamReadString(streamId)
     ---@diagnostic disable-next-line: assign-type-mismatch
-    self.area = g_landscapingManager:getAreaByUniqueId(uniqueId)
+    local area = g_landscapingManager:getAreaByUniqueId(uniqueId)
 
-    if self.area ~= nil then
+    if area ~= nil then
+        self.area = area:clone()
         self.area:readStream(streamId, connection)
         self:run(connection)
     else
@@ -50,6 +51,10 @@ end
 
 ---@param connection Connection
 function AreaUpdateEvent:run(connection)
+    if not ModUtils.getEventConnectionHasPermission(connection, 'landscaping') then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection)
     end

--- a/scripts/landscaping/events/WaterplaneDeleteEvent.lua
+++ b/scripts/landscaping/events/WaterplaneDeleteEvent.lua
@@ -38,6 +38,10 @@ end
 
 ---@param connection Connection
 function WaterplaneDeleteEvent:run(connection)
+    if not ModUtils.getEventConnectionHasPermission(connection, 'landscaping') then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection)
     end

--- a/scripts/landscaping/events/WaterplaneRegisterEvent.lua
+++ b/scripts/landscaping/events/WaterplaneRegisterEvent.lua
@@ -46,6 +46,10 @@ end
 
 ---@param connection Connection
 function WaterplaneRegisterEvent:run(connection)
+    if not ModUtils.getEventConnectionHasPermission(connection, 'landscaping') then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection)
     end

--- a/scripts/landscaping/events/WaterplaneSetVisibleEvent.lua
+++ b/scripts/landscaping/events/WaterplaneSetVisibleEvent.lua
@@ -44,6 +44,10 @@ end
 
 ---@param connection Connection
 function WaterplaneSetVisibleEvent:run(connection)
+    if not ModUtils.getEventConnectionHasPermission(connection, 'landscaping') then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection)
     end

--- a/scripts/landscaping/events/WaterplaneUpdateEvent.lua
+++ b/scripts/landscaping/events/WaterplaneUpdateEvent.lua
@@ -46,6 +46,10 @@ end
 
 ---@param connection Connection
 function WaterplaneUpdateEvent:run(connection)
+    if not ModUtils.getEventConnectionHasPermission(connection, 'landscaping') then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection)
     end

--- a/scripts/specializations/events/SetMachineActiveEvent.lua
+++ b/scripts/specializations/events/SetMachineActiveEvent.lua
@@ -46,6 +46,10 @@ end
 
 ---@param connection Connection
 function SetMachineActiveEvent:run(connection)
+    if not ModUtils.getEventConnectionHasVehiclePermission(connection, 'landscaping', self.vehicle) then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection, self.vehicle)
     end

--- a/scripts/specializations/events/SetMachineEnabledEvent.lua
+++ b/scripts/specializations/events/SetMachineEnabledEvent.lua
@@ -46,6 +46,10 @@ end
 
 ---@param connection Connection
 function SetMachineEnabledEvent:run(connection)
+    if not ModUtils.getEventConnectionHasVehiclePermission(connection, 'manageRights', self.vehicle) then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection, self.vehicle)
     end

--- a/scripts/specializations/events/SetMachineFillTypeEvent.lua
+++ b/scripts/specializations/events/SetMachineFillTypeEvent.lua
@@ -45,6 +45,10 @@ end
 
 ---@param connection Connection
 function SetMachineFillTypeEvent:run(connection)
+    if not ModUtils.getEventConnectionHasVehiclePermission(connection, 'landscaping', self.vehicle) then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection, self.vehicle)
     end

--- a/scripts/specializations/events/SetMachineInputAreaEnabledEvent.lua
+++ b/scripts/specializations/events/SetMachineInputAreaEnabledEvent.lua
@@ -40,6 +40,10 @@ end
 
 ---@param connection Connection
 function SetMachineInputAreaEnabledEvent:run(connection)
+    if not ModUtils.getEventConnectionHasVehiclePermission(connection, 'landscaping', self.vehicle) then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection, self.vehicle)
     end

--- a/scripts/specializations/events/SetMachineInputAreaIdEvent.lua
+++ b/scripts/specializations/events/SetMachineInputAreaIdEvent.lua
@@ -47,6 +47,10 @@ function SetMachineInputAreaIdEvent:readStream(streamId, connection)
 end
 
 function SetMachineInputAreaIdEvent:run(connection)
+    if not ModUtils.getEventConnectionHasVehiclePermission(connection, 'landscaping', self.vehicle) then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection, self.vehicle)
     end

--- a/scripts/specializations/events/SetMachineInputLayerEvent.lua
+++ b/scripts/specializations/events/SetMachineInputLayerEvent.lua
@@ -46,6 +46,10 @@ end
 
 ---@param connection Connection
 function SetMachineInputLayerEvent:run(connection)
+    if not ModUtils.getEventConnectionHasVehiclePermission(connection, 'landscaping', self.vehicle) then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection, self.vehicle)
     end

--- a/scripts/specializations/events/SetMachineInputModeEvent.lua
+++ b/scripts/specializations/events/SetMachineInputModeEvent.lua
@@ -46,6 +46,10 @@ end
 
 ---@param connection Connection
 function SetMachineInputModeEvent:run(connection)
+    if not ModUtils.getEventConnectionHasVehiclePermission(connection, 'landscaping', self.vehicle) then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection, self.vehicle)
     end

--- a/scripts/specializations/events/SetMachineOutputAreaEnabledEvent.lua
+++ b/scripts/specializations/events/SetMachineOutputAreaEnabledEvent.lua
@@ -40,6 +40,10 @@ end
 
 ---@param connection Connection
 function SetMachineOutputAreaEnabledEvent:run(connection)
+    if not ModUtils.getEventConnectionHasVehiclePermission(connection, 'landscaping', self.vehicle) then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection, self.vehicle)
     end

--- a/scripts/specializations/events/SetMachineOutputAreaIdEvent.lua
+++ b/scripts/specializations/events/SetMachineOutputAreaIdEvent.lua
@@ -47,6 +47,10 @@ function SetMachineOutputAreaIdEvent:readStream(streamId, connection)
 end
 
 function SetMachineOutputAreaIdEvent:run(connection)
+    if not ModUtils.getEventConnectionHasVehiclePermission(connection, 'landscaping', self.vehicle) then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection, self.vehicle)
     end

--- a/scripts/specializations/events/SetMachineOutputLayerEvent.lua
+++ b/scripts/specializations/events/SetMachineOutputLayerEvent.lua
@@ -44,6 +44,10 @@ end
 
 ---@param connection Connection
 function SetMachineOutputLayerEvent:run(connection)
+    if not ModUtils.getEventConnectionHasVehiclePermission(connection, 'landscaping', self.vehicle) then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, false, connection, self.vehicle)
     end

--- a/scripts/specializations/events/SetMachineOutputModeEvent.lua
+++ b/scripts/specializations/events/SetMachineOutputModeEvent.lua
@@ -46,6 +46,10 @@ end
 
 ---@param connection Connection
 function SetMachineOutputModeEvent:run(connection)
+    if not ModUtils.getEventConnectionHasVehiclePermission(connection, 'landscaping', self.vehicle) then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection, self.vehicle)
     end

--- a/scripts/specializations/events/SetMachineResourcesEvent.lua
+++ b/scripts/specializations/events/SetMachineResourcesEvent.lua
@@ -46,6 +46,10 @@ end
 
 ---@param connection Connection
 function SetMachineResourcesEvent:run(connection)
+    if not ModUtils.getEventConnectionHasVehiclePermission(connection, 'manageRights', self.vehicle) then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection, self.vehicle)
     end

--- a/scripts/specializations/events/SetMachineStateEvent.lua
+++ b/scripts/specializations/events/SetMachineStateEvent.lua
@@ -47,6 +47,10 @@ end
 
 ---@param connection Connection
 function SetMachineStateEvent:run(connection)
+    if not ModUtils.getEventConnectionHasVehiclePermission(connection, 'landscaping', self.vehicle) then
+        return
+    end
+
     if not connection:getIsServer() then
         g_server:broadcastEvent(self, nil, connection, self.vehicle)
     end

--- a/tests/test_multiplayer_authorization.lua
+++ b/tests/test_multiplayer_authorization.lua
@@ -1,0 +1,340 @@
+local testFilename = debug.getinfo(1, 'S').source:sub(2)
+local projectDirectory = testFilename:match('^(.*)/tests/[^/]+$')
+
+if projectDirectory == nil and testFilename:match('^tests/[^/]+$') then
+    projectDirectory = '.'
+end
+
+if projectDirectory == nil then
+    error('Run this test from a file inside the tests directory.')
+end
+
+local function loadProjectFile(filename)
+    dofile(projectDirectory .. '/' .. filename)
+end
+
+local function assertEqual(actual, expected, message)
+    if actual ~= expected then
+        error(string.format('%s: expected %s, got %s', message, tostring(expected), tostring(actual)), 2)
+    end
+end
+
+local function copyTable(values)
+    local result = {}
+
+    for key, value in pairs(values) do
+        result[key] = value
+    end
+
+    return result
+end
+
+Event = {}
+
+function Event.new(mt)
+    return setmetatable({}, mt)
+end
+
+function Class(classTable)
+    return { __index = classTable }
+end
+
+function InitEventClass()
+end
+
+loadProjectFile('scripts/ModUtils.lua')
+
+local eventFiles = {
+    'scripts/events/SetDefaultEnabledEvent.lua',
+    'scripts/events/SetEnabledEvent.lua',
+    'scripts/events/SetMaterialsEvent.lua',
+    'scripts/events/SetResourcesEvent.lua',
+    'scripts/landscaping/events/AreaDeleteEvent.lua',
+    'scripts/landscaping/events/AreaRegisterEvent.lua',
+    'scripts/landscaping/events/AreaUpdateEvent.lua',
+    'scripts/landscaping/events/WaterplaneDeleteEvent.lua',
+    'scripts/landscaping/events/WaterplaneRegisterEvent.lua',
+    'scripts/landscaping/events/WaterplaneSetVisibleEvent.lua',
+    'scripts/landscaping/events/WaterplaneUpdateEvent.lua',
+    'scripts/specializations/events/SetMachineActiveEvent.lua',
+    'scripts/specializations/events/SetMachineEnabledEvent.lua',
+    'scripts/specializations/events/SetMachineFillTypeEvent.lua',
+    'scripts/specializations/events/SetMachineInputAreaEnabledEvent.lua',
+    'scripts/specializations/events/SetMachineInputAreaIdEvent.lua',
+    'scripts/specializations/events/SetMachineInputLayerEvent.lua',
+    'scripts/specializations/events/SetMachineInputModeEvent.lua',
+    'scripts/specializations/events/SetMachineOutputAreaEnabledEvent.lua',
+    'scripts/specializations/events/SetMachineOutputAreaIdEvent.lua',
+    'scripts/specializations/events/SetMachineOutputLayerEvent.lua',
+    'scripts/specializations/events/SetMachineOutputModeEvent.lua',
+    'scripts/specializations/events/SetMachineResourcesEvent.lua',
+    'scripts/specializations/events/SetMachineStateEvent.lua',
+}
+
+for _, filename in ipairs(eventFiles) do
+    loadProjectFile(filename)
+end
+
+local mutationCount = 0
+local broadcastCount = 0
+
+local function recordMutation()
+    mutationCount = mutationCount + 1
+end
+
+local function resetCounts()
+    mutationCount = 0
+    broadcastCount = 0
+end
+
+local function newConnection(options)
+    options = options or {}
+
+    local connection = {
+        permissions = options.permissions or {},
+        permittedFarmIds = options.permittedFarmIds or {},
+    }
+
+    function connection:getIsServer()
+        return options.isServer == true
+    end
+
+    function connection:getIsMasterUser()
+        return options.isAdministrator == true
+    end
+
+    return connection
+end
+
+g_currentMission = {
+    userManager = {
+        getUserByConnection = function (_, connection)
+            return connection
+        end,
+    },
+}
+
+function g_currentMission:getHasPlayerPermission(permission, connection, farmId)
+    if connection == nil or connection.permissions[permission] ~= true then
+        return false
+    end
+
+    return farmId == nil or connection.permittedFarmIds[farmId] == true
+end
+
+g_server = {
+    broadcastEvent = function ()
+        broadcastCount = broadcastCount + 1
+    end,
+}
+
+g_modSettings = {
+    setDefaultEnabled = recordMutation,
+    setIsEnabled = recordMutation,
+    setMaterials = recordMutation,
+}
+
+g_resourceManager = {
+    setIsActive = recordMutation,
+}
+
+g_landscapingManager = {
+    deleteAreaByUniqueId = recordMutation,
+    registerArea = recordMutation,
+    updateArea = recordMutation,
+    deleteWaterplaneByUniqueId = recordMutation,
+    registerWaterplane = recordMutation,
+    setWaterplaneVisible = recordMutation,
+    updateWaterplane = recordMutation,
+}
+
+local vehicle = {
+    ownerFarmId = 7,
+}
+
+function vehicle:getOwnerFarmId()
+    return self.ownerFarmId
+end
+
+function vehicle:getIsSynchronized()
+    return true
+end
+
+vehicle.setMachineActive = recordMutation
+vehicle.setMachineEnabled = recordMutation
+vehicle.setMachineFillTypeIndex = recordMutation
+vehicle.setIsMachineInputAreaEnabled = recordMutation
+vehicle.setMachineInputAreaId = recordMutation
+vehicle.setMachineInputLayerId = recordMutation
+vehicle.setInputMode = recordMutation
+vehicle.setIsMachineOutputAreaEnabled = recordMutation
+vehicle.setMachineOutputAreaId = recordMutation
+vehicle.setMachineOutputLayerId = recordMutation
+vehicle.setOutputMode = recordMutation
+vehicle.setResourcesEnabled = recordMutation
+vehicle.setMachineState = recordMutation
+
+local unauthorizedConnection = newConnection()
+local administratorConnection = newConnection({ isAdministrator = true })
+local landscapingConnection = newConnection({
+    permissions = { landscaping = true },
+    permittedFarmIds = { [7] = true },
+})
+local farmManagerConnection = newConnection({
+    permissions = { manageRights = true },
+    permittedFarmIds = { [7] = true },
+})
+local wrongFarmConnection = newConnection({
+    permissions = { landscaping = true, manageRights = true },
+    permittedFarmIds = { [9] = true },
+})
+local serverConnection = newConnection({ isServer = true })
+
+local globalEvents = {
+    { name = 'SetDefaultEnabledEvent', class = SetDefaultEnabledEvent, values = { defaultEnabled = true } },
+    { name = 'SetEnabledEvent', class = SetEnabledEvent, values = { enabled = true } },
+    { name = 'SetMaterialsEvent', class = SetMaterialsEvent, values = { materials = { 'DIRT' } } },
+    { name = 'SetResourcesEvent', class = SetResourcesEvent, values = { available = true, active = true } },
+}
+
+local landscapingEvents = {
+    { name = 'AreaDeleteEvent', class = AreaDeleteEvent, values = { uniqueId = 'area' } },
+    { name = 'AreaRegisterEvent', class = AreaRegisterEvent, values = { area = {} } },
+    { name = 'AreaUpdateEvent', class = AreaUpdateEvent, values = { area = {} } },
+    { name = 'WaterplaneDeleteEvent', class = WaterplaneDeleteEvent, values = { uniqueId = 'waterplane' } },
+    { name = 'WaterplaneRegisterEvent', class = WaterplaneRegisterEvent, values = { waterplane = {} } },
+    { name = 'WaterplaneSetVisibleEvent', class = WaterplaneSetVisibleEvent, values = { uniqueId = 'waterplane', visible = true } },
+    { name = 'WaterplaneUpdateEvent', class = WaterplaneUpdateEvent, values = { waterplane = {} } },
+}
+
+local machineEvents = {
+    { name = 'SetMachineActiveEvent', class = SetMachineActiveEvent, permission = 'landscaping', values = { active = true } },
+    { name = 'SetMachineEnabledEvent', class = SetMachineEnabledEvent, permission = 'manageRights', values = { enabled = true } },
+    { name = 'SetMachineFillTypeEvent', class = SetMachineFillTypeEvent, permission = 'landscaping', values = { fillTypeIndex = 1 } },
+    { name = 'SetMachineInputAreaEnabledEvent', class = SetMachineInputAreaEnabledEvent, permission = 'landscaping', values = { enabled = true } },
+    { name = 'SetMachineInputAreaIdEvent', class = SetMachineInputAreaIdEvent, permission = 'landscaping', values = { id = 'area' } },
+    { name = 'SetMachineInputLayerEvent', class = SetMachineInputLayerEvent, permission = 'landscaping', values = { terrainLayerId = 1 } },
+    { name = 'SetMachineInputModeEvent', class = SetMachineInputModeEvent, permission = 'landscaping', values = { mode = 1 } },
+    { name = 'SetMachineOutputAreaEnabledEvent', class = SetMachineOutputAreaEnabledEvent, permission = 'landscaping', values = { enabled = true } },
+    { name = 'SetMachineOutputAreaIdEvent', class = SetMachineOutputAreaIdEvent, permission = 'landscaping', values = { id = 'area' } },
+    { name = 'SetMachineOutputLayerEvent', class = SetMachineOutputLayerEvent, permission = 'landscaping', values = { terrainLayerId = 1 } },
+    { name = 'SetMachineOutputModeEvent', class = SetMachineOutputModeEvent, permission = 'landscaping', values = { mode = 1 } },
+    { name = 'SetMachineResourcesEvent', class = SetMachineResourcesEvent, permission = 'manageRights', values = { enabled = true } },
+    { name = 'SetMachineStateEvent', class = SetMachineStateEvent, permission = 'landscaping', values = { state = {} } },
+}
+
+local function runEvent(eventDefinition, connection)
+    local event = copyTable(eventDefinition.values)
+    event.vehicle = event.vehicle or vehicle
+    eventDefinition.class.run(event, connection)
+end
+
+for _, eventDefinition in ipairs(globalEvents) do
+    resetCounts()
+    runEvent(eventDefinition, unauthorizedConnection)
+    assertEqual(mutationCount, 0, eventDefinition.name .. ' accepted a non-administrator')
+    assertEqual(broadcastCount, 0, eventDefinition.name .. ' broadcast an unauthorized request')
+
+    resetCounts()
+    runEvent(eventDefinition, administratorConnection)
+    assertEqual(mutationCount, 1, eventDefinition.name .. ' rejected an administrator')
+    assertEqual(broadcastCount, 1, eventDefinition.name .. ' did not broadcast an administrator change')
+
+    resetCounts()
+    runEvent(eventDefinition, serverConnection)
+    assertEqual(mutationCount, 1, eventDefinition.name .. ' rejected server replication')
+    assertEqual(broadcastCount, 0, eventDefinition.name .. ' rebroadcast a server event')
+end
+
+for _, eventDefinition in ipairs(landscapingEvents) do
+    resetCounts()
+    runEvent(eventDefinition, unauthorizedConnection)
+    assertEqual(mutationCount, 0, eventDefinition.name .. ' accepted a client without landscaping permission')
+    assertEqual(broadcastCount, 0, eventDefinition.name .. ' broadcast an unauthorized request')
+
+    resetCounts()
+    runEvent(eventDefinition, landscapingConnection)
+    assertEqual(mutationCount, 1, eventDefinition.name .. ' rejected a client with landscaping permission')
+    assertEqual(broadcastCount, 1, eventDefinition.name .. ' did not broadcast an authorized change')
+
+    resetCounts()
+    runEvent(eventDefinition, serverConnection)
+    assertEqual(mutationCount, 1, eventDefinition.name .. ' rejected server replication')
+    assertEqual(broadcastCount, 0, eventDefinition.name .. ' rebroadcast a server event')
+end
+
+for _, eventDefinition in ipairs(machineEvents) do
+    local authorizedConnection = eventDefinition.permission == 'manageRights' and farmManagerConnection or landscapingConnection
+
+    resetCounts()
+    runEvent(eventDefinition, unauthorizedConnection)
+    assertEqual(mutationCount, 0, eventDefinition.name .. ' accepted a client without permission')
+    assertEqual(broadcastCount, 0, eventDefinition.name .. ' broadcast an unauthorized request')
+
+    resetCounts()
+    runEvent(eventDefinition, wrongFarmConnection)
+    assertEqual(mutationCount, 0, eventDefinition.name .. ' accepted a request for another farm')
+    assertEqual(broadcastCount, 0, eventDefinition.name .. ' broadcast a request for another farm')
+
+    resetCounts()
+    runEvent(eventDefinition, authorizedConnection)
+    assertEqual(mutationCount, 1, eventDefinition.name .. ' rejected an authorized client')
+    assertEqual(broadcastCount, 1, eventDefinition.name .. ' did not broadcast an authorized change')
+
+    resetCounts()
+    runEvent(eventDefinition, serverConnection)
+    assertEqual(mutationCount, 1, eventDefinition.name .. ' rejected server replication')
+    assertEqual(broadcastCount, 0, eventDefinition.name .. ' rebroadcast a server event')
+end
+
+local authoritativeArea = {
+    uniqueId = 'area',
+    readCount = 0,
+}
+local receivedArea
+
+function authoritativeArea:clone()
+    local clone = {
+        uniqueId = self.uniqueId,
+        readCount = 0,
+    }
+
+    function clone:readStream()
+        self.readCount = self.readCount + 1
+    end
+
+    return clone
+end
+
+function authoritativeArea:readStream()
+    self.readCount = self.readCount + 1
+end
+
+streamReadString = function ()
+    return authoritativeArea.uniqueId
+end
+
+g_landscapingManager.getAreaByUniqueId = function ()
+    return authoritativeArea
+end
+
+g_landscapingManager.updateArea = function (_, area)
+    receivedArea = area
+    recordMutation()
+end
+
+resetCounts()
+AreaUpdateEvent.readStream(setmetatable({}, { __index = AreaUpdateEvent }), 0, unauthorizedConnection)
+assertEqual(authoritativeArea.readCount, 0, 'AreaUpdateEvent changed the registered area before authorization')
+assertEqual(mutationCount, 0, 'AreaUpdateEvent applied an unauthorized streamed update')
+assertEqual(broadcastCount, 0, 'AreaUpdateEvent broadcast an unauthorized streamed update')
+
+resetCounts()
+AreaUpdateEvent.readStream(setmetatable({}, { __index = AreaUpdateEvent }), 0, landscapingConnection)
+assertEqual(authoritativeArea.readCount, 0, 'AreaUpdateEvent changed the registered area while decoding an authorized update')
+assertEqual(receivedArea ~= authoritativeArea, true, 'AreaUpdateEvent did not apply a separate decoded area')
+assertEqual(receivedArea.readCount, 1, 'AreaUpdateEvent did not decode the authorized update')
+assertEqual(mutationCount, 1, 'AreaUpdateEvent rejected an authorized streamed update')
+assertEqual(broadcastCount, 1, 'AreaUpdateEvent did not broadcast an authorized streamed update')
+
+print(string.format('All %d multiplayer authorization checks passed.', #globalEvents + #landscapingEvents + #machineEvents))


### PR DESCRIPTION
TerraFarm currently trusts several events received from multiplayer clients. A modified client can use these events to change global settings or alter machines and landscaping without the required permissions.

This change validates permissions on the server before an event is broadcast or applied. Global settings require administrator access, while landscaping and machine changes use the existing permissions and owning-farm scope.

It also limits material-list serialization and avoids changing a live landscaping area before an update has been authorized.

Tested with:

- the 24-event multiplayer authorization regression;
- Lua syntax validation;
- ZIP integrity and `git diff --check`;
- an FS25 1.21 dedicated-server session, where an ordinary client's requests were rejected and the same global-setting change succeeded after administrator login.
