### PR TITLE
Keep landscaping counts within multiplayer limits

### DIFF
--- a/scripts/events/SetLandscapingAreasEvent.lua
+++ b/scripts/events/SetLandscapingAreasEvent.lua
@@ -24,6 +24,15 @@ end
 function SetLandscapingAreasEvent:writeStream(streamId, connection)
     local areas = g_landscapingManager:getAreas()
 
+    assert(
+        #areas <= LandscapingArea.MAX_NUM_AREAS,
+        string.format(
+            'Cannot write %d landscaping areas; maximum is %d',
+            #areas,
+            LandscapingArea.MAX_NUM_AREAS
+        )
+    )
+
     streamWriteUIntN(streamId, #areas, LandscapingArea.SEND_NUM_BITS_AREAS)
 
     for _, area in ipairs(areas) do

--- a/scripts/events/SetWaterplanesEvent.lua
+++ b/scripts/events/SetWaterplanesEvent.lua
@@ -24,6 +24,15 @@ end
 function SetWaterplanesEvent:writeStream(streamId, connection)
     local waterplanes = g_landscapingManager:getWaterplanes()
 
+    assert(
+        #waterplanes <= LandscapingWaterplane.MAX_NUM_PLANES,
+        string.format(
+            'Cannot write %d waterplanes; maximum is %d',
+            #waterplanes,
+            LandscapingWaterplane.MAX_NUM_PLANES
+        )
+    )
+
     streamWriteUIntN(streamId, #waterplanes, LandscapingWaterplane.SEND_NUM_BITS_PLANES)
 
     for _, waterplane in ipairs(waterplanes) do

--- a/scripts/gui/editor/Editor.lua
+++ b/scripts/gui/editor/Editor.lua
@@ -395,7 +395,7 @@ function Editor:splitSelectedSegment()
     local selectedIndex = self.selectedIndex
     local points = self.points
 
-    if selectedIndex ~= nil then
+    if selectedIndex ~= nil and #points < self.numPointsLimit then
         local selectedPos = points[selectedIndex]
         local prevPos = points[selectedIndex - 1]
 

--- a/scripts/gui/editor/PathEditor.lua
+++ b/scripts/gui/editor/PathEditor.lua
@@ -124,7 +124,7 @@ function PathEditor:createPoint()
     local points = self.points
     local targetPos = self:getTargetPos()
 
-    if targetPos ~= nil and #points <= self.numPointsLimit then
+    if targetPos ~= nil and #points < self.numPointsLimit then
         local selectedIndex = self.selectedIndex
         local targetIndex = selectedIndex or 1
 

--- a/scripts/gui/editor/PolygonEditor.lua
+++ b/scripts/gui/editor/PolygonEditor.lua
@@ -99,7 +99,7 @@ function PolygonEditor:splitSelectedSegment()
     local points = self.points
     local numPoints = #points
 
-    if selectedIndex ~= nil then
+    if selectedIndex ~= nil and numPoints < self.numPointsLimit then
         local selectedPos = points[selectedIndex]
         local prevPos = points[selectedIndex - 1]
 
@@ -189,7 +189,7 @@ function PolygonEditor:createPoint()
     local numPoints = #points
     local targetPos = self:getTargetPos()
 
-    if targetPos ~= nil and numPoints <= self.numPointsLimit then
+    if targetPos ~= nil and numPoints < self.numPointsLimit then
         local selectedIndex = self.selectedIndex
         local targetIndex = selectedIndex or 1
 

--- a/scripts/landscaping/LandscapingAreaPath.lua
+++ b/scripts/landscaping/LandscapingAreaPath.lua
@@ -52,7 +52,7 @@ end
 ---@return boolean
 ---@nodiscard
 function LandscapingAreaPath:getCanAddPoint()
-    return #self.points <= LandscapingAreaPath.MAX_NUM_POINTS
+    return #self.points < LandscapingAreaPath.MAX_NUM_POINTS
 end
 
 ---@param x number
@@ -410,6 +410,16 @@ function LandscapingAreaPath:loadFromXMLFile(xmlFile, key)
         self.points = {}
 
         for _, itemKey in xmlFile:iterator(key .. '.points.point') do
+            if #self.points >= LandscapingAreaPath.MAX_NUM_POINTS then
+                Logging.xmlError(
+                    xmlFile,
+                    'LandscapingAreaPath:loadFromXMLFile() Too many points in "%s" (maximum is %d)',
+                    key,
+                    LandscapingAreaPath.MAX_NUM_POINTS
+                )
+                return false
+            end
+
             local x, y, z = xmlFile:getValue(itemKey .. '#position')
 
             table.insert(self.points, { x, y, z })
@@ -443,10 +453,19 @@ end
 ---@param streamId number
 ---@param connection Connection
 function LandscapingAreaPath:writeStream(streamId, connection)
+    assert(
+        #self.points <= LandscapingAreaPath.MAX_NUM_POINTS,
+        string.format(
+            'Cannot write %d path points; maximum is %d',
+            #self.points,
+            LandscapingAreaPath.MAX_NUM_POINTS
+        )
+    )
+
     self:superClass().writeStream(self, streamId, connection)
 
     streamWriteFloat32(streamId, self.width)
-    streamWriteUIntN(streamId, #self.points, LandscapingAreaPolygon.SEND_NUM_BITS_POINTS)
+    streamWriteUIntN(streamId, #self.points, LandscapingAreaPath.SEND_NUM_BITS_POINTS)
 
     for _, point in ipairs(self.points) do
         ModUtils.writeCompressedXYZPos(streamId, point[1], point[2], point[3])
@@ -460,7 +479,7 @@ function LandscapingAreaPath:readStream(streamId, connection)
 
     self.width = streamReadFloat32(streamId)
 
-    local numPoints = streamReadUIntN(streamId, LandscapingAreaPolygon.SEND_NUM_BITS_POINTS)
+    local numPoints = streamReadUIntN(streamId, LandscapingAreaPath.SEND_NUM_BITS_POINTS)
 
     self.points = {}
 

--- a/scripts/landscaping/LandscapingAreaPolygon.lua
+++ b/scripts/landscaping/LandscapingAreaPolygon.lua
@@ -60,7 +60,7 @@ end
 ---@return boolean
 ---@nodiscard
 function LandscapingAreaPolygon:getCanAddPoint()
-    return #self.points <= LandscapingAreaPolygon.MAX_NUM_POINTS
+    return #self.points < LandscapingAreaPolygon.MAX_NUM_POINTS
 end
 
 ---@param x number worldPosX
@@ -138,6 +138,16 @@ function LandscapingAreaPolygon:loadFromXMLFile(xmlFile, key)
         local y = self.targetY
 
         for _, itemKey in xmlFile:iterator(key .. '.points.point') do
+            if #self.points >= LandscapingAreaPolygon.MAX_NUM_POINTS then
+                Logging.xmlError(
+                    xmlFile,
+                    'LandscapingAreaPolygon:loadFromXMLFile() Too many points in "%s" (maximum is %d)',
+                    key,
+                    LandscapingAreaPolygon.MAX_NUM_POINTS
+                )
+                return false
+            end
+
             local x, _, z = xmlFile:getValue(itemKey .. '#position')
 
             table.insert(self.points, { x, y, z })
@@ -176,6 +186,15 @@ end
 ---@param streamId number
 ---@param connection Connection
 function LandscapingAreaPolygon:writeStream(streamId, connection)
+    assert(
+        #self.points <= LandscapingAreaPolygon.MAX_NUM_POINTS,
+        string.format(
+            'Cannot write %d polygon points; maximum is %d',
+            #self.points,
+            LandscapingAreaPolygon.MAX_NUM_POINTS
+        )
+    )
+
     self:superClass().writeStream(self, streamId, connection)
 
     streamWriteFloat32(streamId, self.targetY)

--- a/scripts/landscaping/LandscapingManager.lua
+++ b/scripts/landscaping/LandscapingManager.lua
@@ -476,13 +476,13 @@ end
 function LandscapingManager:getCanCreateArea()
     local i = 0
     for _, _ in pairs(self.areas) do i = i + 1 end
-    return i <= LandscapingArea.MAX_NUM_AREAS
+    return i < LandscapingArea.MAX_NUM_AREAS
 end
 
 function LandscapingManager:getCanCreateWaterplane()
     local i = 0
     for _, _ in pairs(self.waterplanes) do i = i + 1 end
-    return i <= LandscapingWaterplane.MAX_NUM_PLANES
+    return i < LandscapingWaterplane.MAX_NUM_PLANES
 end
 
 ---@param className string
@@ -501,6 +501,8 @@ function LandscapingManager:createArea(className, uniqueId)
         else
             Logging.error('LandscapingManager:createArea() Unknown class "%s"', tostring(className))
         end
+    else
+        Logging.error('LandscapingManager:createArea() can not create any more areas, MAX_NUM_AREAS = %d', LandscapingArea.MAX_NUM_AREAS)
     end
 end
 

--- a/scripts/landscaping/LandscapingWaterplane.lua
+++ b/scripts/landscaping/LandscapingWaterplane.lua
@@ -106,7 +106,7 @@ end
 ---@return boolean
 ---@nodiscard
 function LandscapingWaterplane:getCanAddPoint()
-    return #self.points <= LandscapingAreaPolygon.MAX_NUM_POINTS
+    return #self.points < LandscapingAreaPolygon.MAX_NUM_POINTS
 end
 
 ---@return string
@@ -161,6 +161,16 @@ function LandscapingWaterplane:loadFromXMLFile(xmlFile, key)
     local y = self.targetY
 
     for _, itemKey in xmlFile:iterator(key .. '.points.point') do
+        if #self.points >= LandscapingAreaPolygon.MAX_NUM_POINTS then
+            Logging.xmlError(
+                xmlFile,
+                'LandscapingWaterplane:loadFromXMLFile() Too many points in "%s" (maximum is %d)',
+                key,
+                LandscapingAreaPolygon.MAX_NUM_POINTS
+            )
+            return false
+        end
+
         local x, _, z = xmlFile:getValue(itemKey .. '#position')
 
         table.insert(self.points, { x, y, z })
@@ -202,6 +212,15 @@ end
 ---@param streamId number
 ---@param connection Connection
 function LandscapingWaterplane:writeStream(streamId, connection)
+    assert(
+        #self.points <= LandscapingAreaPolygon.MAX_NUM_POINTS,
+        string.format(
+            'Cannot write %d waterplane points; maximum is %d',
+            #self.points,
+            LandscapingAreaPolygon.MAX_NUM_POINTS
+        )
+    )
+
     streamWriteString(streamId, self.name)
     streamWriteBool(streamId, self.visible)
     streamWriteUInt8(streamId, self.color)

--- a/tests/test_multiplayer_count_limits.lua
+++ b/tests/test_multiplayer_count_limits.lua
@@ -1,0 +1,422 @@
+local testFilename = debug.getinfo(1, 'S').source:sub(2)
+local projectDirectory = testFilename:match('^(.*)/tests/[^/]+$')
+
+if projectDirectory == nil and testFilename:match('^tests/[^/]+$') then
+    projectDirectory = '.'
+end
+
+if projectDirectory == nil then
+    error('Run this test from a file inside the tests directory.')
+end
+
+local function loadProjectFile(filename)
+    local path = projectDirectory .. '/' .. filename
+    local file = assert(io.open(path, 'r'))
+    local contents = file:read('*a')
+    file:close()
+
+    contents = contents:gsub(
+        '([%w_%.%[%]]+)%s*([%+%-%*/])=%s*([^\r\n]+)',
+        function (name, operator, value)
+            return string.format('%s = %s %s %s', name, name, operator, value)
+        end
+    )
+    contents = contents:gsub('([ \t]*)continue([ \t]*)(\r?\n)', '%1-- continue%2%3')
+    contents = contents:gsub(
+        'g_landscapingManager = LandscapingManager%.new%(%)[\r\n]+g_landscapingManager:loadShapes%(%)',
+        ''
+    )
+
+    assert(load(contents, '@' .. path))()
+end
+
+local function assertEqual(actual, expected, message)
+    if actual ~= expected then
+        error(string.format('%s: expected %s, got %s', message, tostring(expected), tostring(actual)), 2)
+    end
+end
+
+local function assertFails(callback, message)
+    local success = pcall(callback)
+
+    if success then
+        error(message, 2)
+    end
+end
+
+local function makeList(count, factory)
+    local result = {}
+
+    for i = 1, count do
+        result[i] = factory ~= nil and factory(i) or {}
+    end
+
+    return result
+end
+
+local function makeCollection(count)
+    local result = {}
+
+    for i = 1, count do
+        result[string.format('item_%d', i)] = {}
+    end
+
+    return result
+end
+
+g_modDirectory = projectDirectory .. '/'
+g_i18n = {
+    getText = function (_, key)
+        return key
+    end
+}
+
+XMLValueType = {
+    BOOL = 1,
+    FLOAT = 2,
+    INT = 3,
+    STRING = 4,
+    VECTOR_3 = 5,
+}
+
+XMLSchema = {
+    new = function ()
+        return {
+            register = function ()
+            end
+        }
+    end
+}
+
+Event = {}
+
+function Event.new(mt)
+    return setmetatable({}, mt)
+end
+
+function Class(classTable)
+    return { __index = classTable }
+end
+
+function InitEventClass()
+end
+
+function source()
+end
+
+Logging = {
+    xmlErrors = 0,
+    xmlError = function ()
+        Logging.xmlErrors = Logging.xmlErrors + 1
+    end,
+    error = function ()
+    end,
+    warning = function ()
+    end,
+}
+
+ModUtils = {}
+AreaEditor = {}
+ScreenElement = {}
+EditorDirection = {
+    NEGATIVE = -1,
+    POSITIVE = 1,
+}
+
+loadProjectFile('scripts/landscaping/LandscapingArea.lua')
+loadProjectFile('scripts/landscaping/LandscapingAreaPolygon.lua')
+loadProjectFile('scripts/landscaping/LandscapingAreaPath.lua')
+loadProjectFile('scripts/landscaping/LandscapingWaterplane.lua')
+loadProjectFile('scripts/landscaping/LandscapingManager.lua')
+loadProjectFile('scripts/events/SetLandscapingAreasEvent.lua')
+loadProjectFile('scripts/events/SetWaterplanesEvent.lua')
+loadProjectFile('scripts/gui/editor/Editor.lua')
+loadProjectFile('scripts/gui/editor/PolygonEditor.lua')
+loadProjectFile('scripts/gui/editor/PathEditor.lua')
+
+local areaSuperClass = {
+    loadFromXMLFile = function ()
+        return true
+    end,
+    writeStream = function ()
+    end,
+}
+
+LandscapingAreaPolygon.superClass = function ()
+    return areaSuperClass
+end
+
+LandscapingAreaPath.superClass = function ()
+    return areaSuperClass
+end
+
+local maxPoints = LandscapingAreaPolygon.MAX_NUM_POINTS
+local maxAreas = LandscapingArea.MAX_NUM_AREAS
+local maxWaterplanes = LandscapingWaterplane.MAX_NUM_PLANES
+
+assertEqual(
+    LandscapingAreaPolygon.getCanAddPoint({ points = makeList(maxPoints - 1) }),
+    true,
+    'A polygon rejected its last encodable point'
+)
+assertEqual(
+    LandscapingAreaPolygon.getCanAddPoint({ points = makeList(maxPoints) }),
+    false,
+    'A polygon allowed a point beyond the wire limit'
+)
+assertEqual(
+    LandscapingAreaPath.getCanAddPoint({ points = makeList(maxPoints) }),
+    false,
+    'A path allowed a point beyond the wire limit'
+)
+assertEqual(
+    LandscapingWaterplane.getCanAddPoint({ points = makeList(maxPoints) }),
+    false,
+    'A waterplane allowed a point beyond the wire limit'
+)
+
+assertEqual(
+    LandscapingManager.getCanCreateArea({ areas = makeCollection(maxAreas - 1) }),
+    true,
+    'The manager rejected its last encodable landscaping area'
+)
+assertEqual(
+    LandscapingManager.getCanCreateArea({ areas = makeCollection(maxAreas) }),
+    false,
+    'The manager allowed a landscaping area beyond the wire limit'
+)
+assertEqual(
+    LandscapingManager.getCanCreateWaterplane({ waterplanes = makeCollection(maxWaterplanes - 1) }),
+    true,
+    'The manager rejected its last encodable waterplane'
+)
+assertEqual(
+    LandscapingManager.getCanCreateWaterplane({ waterplanes = makeCollection(maxWaterplanes) }),
+    false,
+    'The manager allowed a waterplane beyond the wire limit'
+)
+
+local fullManager = {
+    areas = makeCollection(maxAreas),
+    waterplanes = makeCollection(maxWaterplanes),
+    getCanCreateArea = LandscapingManager.getCanCreateArea,
+    getCanCreateWaterplane = LandscapingManager.getCanCreateWaterplane,
+}
+
+LandscapingManager.registerArea(fullManager, { uniqueId = 'extra_area' }, true)
+assertEqual(fullManager.areas.extra_area, nil, 'The manager registered an unencodable landscaping area')
+
+LandscapingManager.registerWaterplane(fullManager, { uniqueId = 'extra_waterplane' }, true)
+assertEqual(fullManager.waterplanes.extra_waterplane, nil, 'The manager registered an unencodable waterplane')
+
+local function makeEditor(points, limit)
+    return {
+        points = points,
+        numPointsLimit = limit,
+        placementDirection = EditorDirection.POSITIVE,
+        getTargetPos = function ()
+            return { 1, 2, 3 }
+        end,
+        getTargetY = function ()
+            return 2
+        end,
+        updateBorder = function ()
+        end,
+        setHasChanged = function ()
+        end,
+        setSelectedIndex = function ()
+        end,
+    }
+end
+
+local polygonEditor = makeEditor(makeList(maxPoints), maxPoints)
+assertEqual(PolygonEditor.createPoint(polygonEditor), false, 'The polygon editor inserted an unencodable point')
+assertEqual(#polygonEditor.points, maxPoints, 'The polygon editor changed a full point list')
+
+local pathEditor = makeEditor(makeList(maxPoints), maxPoints)
+PathEditor.createPoint(pathEditor)
+assertEqual(#pathEditor.points, maxPoints, 'The path editor inserted an unencodable point')
+
+local polygonSplitEditor = makeEditor(makeList(maxPoints), maxPoints)
+polygonSplitEditor.selectedIndex = 2
+PolygonEditor.splitSelectedSegment(polygonSplitEditor)
+assertEqual(#polygonSplitEditor.points, maxPoints, 'The polygon editor split beyond the wire limit')
+
+local pathSplitEditor = makeEditor(makeList(maxPoints), maxPoints)
+pathSplitEditor.selectedIndex = 2
+Editor.splitSelectedSegment(pathSplitEditor)
+assertEqual(#pathSplitEditor.points, maxPoints, 'The path editor split beyond the wire limit')
+
+local function makeXMLFile(pointCount)
+    return {
+        getValue = function (_, path, default)
+            if path:find('#uniqueId', 1, true) ~= nil then
+                return 'test_waterplane'
+            elseif path:find('#targetY', 1, true) ~= nil then
+                return 2
+            elseif path:find('#position', 1, true) ~= nil then
+                return 1, 0, 1
+            end
+
+            return default
+        end,
+        iterator = function ()
+            local index = 0
+
+            return function ()
+                index = index + 1
+
+                if index <= pointCount then
+                    return index, string.format('area.points.point(%d)', index - 1)
+                end
+            end
+        end,
+    }
+end
+
+local function verifyXMLPointLimit(loader, label)
+    Logging.xmlErrors = 0
+
+    local validObject = {
+        points = {},
+        superClass = function ()
+            return areaSuperClass
+        end,
+    }
+    assertEqual(loader(validObject, makeXMLFile(maxPoints), 'area'), true, label .. ' rejected the maximum point count')
+    assertEqual(#validObject.points, maxPoints, label .. ' did not load the maximum point count')
+
+    local oversizedObject = {
+        points = {},
+        superClass = function ()
+            return areaSuperClass
+        end,
+    }
+    assertEqual(loader(oversizedObject, makeXMLFile(maxPoints + 1), 'area'), false, label .. ' accepted too many XML points')
+    assertEqual(Logging.xmlErrors, 1, label .. ' did not report the oversized XML record')
+end
+
+verifyXMLPointLimit(LandscapingAreaPolygon.loadFromXMLFile, 'Polygon XML loading')
+verifyXMLPointLimit(LandscapingAreaPath.loadFromXMLFile, 'Path XML loading')
+verifyXMLPointLimit(LandscapingWaterplane.loadFromXMLFile, 'Waterplane XML loading')
+
+local streamCounts = {}
+local positionWrites = 0
+
+streamWriteUIntN = function (_, value, bits)
+    table.insert(streamCounts, { value = value, bits = bits })
+end
+streamWriteFloat32 = function ()
+end
+streamWriteString = function ()
+end
+streamWriteBool = function ()
+end
+streamWriteUInt8 = function ()
+end
+ModUtils.writeCompressedXYZPos = function ()
+    positionWrites = positionWrites + 1
+end
+
+local function resetStream()
+    streamCounts = {}
+    positionWrites = 0
+end
+
+local function verifyPointWriter(writer, object, label)
+    object.superClass = function ()
+        return areaSuperClass
+    end
+    object.points = makeList(maxPoints + 1, function ()
+        return { 1, 2, 3 }
+    end)
+
+    resetStream()
+    assertFails(function ()
+        writer(object, 0, {})
+    end, label .. ' serialized too many points')
+    assertEqual(#streamCounts, 0, label .. ' wrote part of an oversized record')
+
+    object.points = makeList(maxPoints, function ()
+        return { 1, 2, 3 }
+    end)
+
+    resetStream()
+    writer(object, 0, {})
+    assertEqual(streamCounts[1].value, maxPoints, label .. ' wrote the wrong point count')
+    assertEqual(positionWrites, maxPoints, label .. ' did not preserve the maximum valid point list')
+end
+
+verifyPointWriter(
+    LandscapingAreaPolygon.writeStream,
+    { targetY = 2 },
+    'Polygon network serialization'
+)
+verifyPointWriter(
+    LandscapingAreaPath.writeStream,
+    { width = 4 },
+    'Path network serialization'
+)
+verifyPointWriter(
+    LandscapingWaterplane.writeStream,
+    { name = 'Water', visible = true, color = 1, targetY = 2 },
+    'Waterplane network serialization'
+)
+
+local function makeAreas(count)
+    return makeList(count, function (index)
+        return {
+            className = 'LandscapingAreaPolygon',
+            uniqueId = string.format('area_%d', index),
+            writeStream = function ()
+            end,
+        }
+    end)
+end
+
+local function makeWaterplanes(count)
+    return makeList(count, function (index)
+        return {
+            uniqueId = string.format('waterplane_%d', index),
+            writeStream = function ()
+            end,
+        }
+    end)
+end
+
+local function verifyCollectionWriter(writer, getterName, maxCount, factory, label)
+    local values = factory(maxCount + 1)
+    g_landscapingManager = {
+        [getterName] = function ()
+            return values
+        end
+    }
+
+    resetStream()
+    assertFails(function ()
+        writer({}, 0, {})
+    end, label .. ' serialized too many records')
+    assertEqual(#streamCounts, 0, label .. ' wrote part of an oversized collection')
+
+    values = factory(maxCount)
+    resetStream()
+    writer({}, 0, {})
+    assertEqual(streamCounts[1].value, maxCount, label .. ' did not preserve the maximum valid collection')
+end
+
+verifyCollectionWriter(
+    SetLandscapingAreasEvent.writeStream,
+    'getAreas',
+    maxAreas,
+    makeAreas,
+    'Landscaping-area snapshot'
+)
+verifyCollectionWriter(
+    SetWaterplanesEvent.writeStream,
+    'getWaterplanes',
+    maxWaterplanes,
+    makeWaterplanes,
+    'Waterplane snapshot'
+)
+
+print('All multiplayer count-limit checks passed.')


### PR DESCRIPTION
Several TerraFarm editor limits allow one more entry than the multiplayer count fields can represent. This can produce 64 points or landscaping areas in a six-bit field, or 32 waterplanes in a five-bit field, causing the count to wrap during synchronization.

This change stops point creation and segment splitting at the last representable value, rejects oversized point lists from save data, and validates collection sizes before writing multiplayer snapshots.

Existing saves and editor behavior remain unchanged within the valid limits.

Tested with:

- focused editor, XML, manager, and serializer boundary coverage;
- Lua test syntax validation;
- ZIP integrity and `git diff --check`;
- an FS25 1.21 dedicated-server startup.
