### PR TITLE
Handle TerraFarm save failures independently

### DIFF
--- a/scripts/ModSettings.lua
+++ b/scripts/ModSettings.lua
@@ -229,21 +229,34 @@ function ModSettings:setDefaultMaterials()
     end
 end
 
+---@return boolean
 function ModSettings:saveSettings()
-    if g_server ~= nil then
-        local xmlFile = ModUtils.createSavegameDirectoryXMLFile('modSettings', 'terraFarmSettings.xml', 'settings')
-
-        if xmlFile ~= nil then
-            xmlFile:setBool('settings.enabled', self.enabled)
-            xmlFile:setBool('settings.defaultEnabled', self.defaultEnabled)
-            xmlFile:setBool('settings.resourcesActive', g_resourceManager.active)
-
-            self:saveMaterialSettings(xmlFile)
-
-            xmlFile:save()
-            xmlFile:delete()
-        end
+    if g_server == nil then
+        return true
     end
+
+    local filename = ModUtils.getSavegameDirectoryFilename('terraFarmSettings.xml') or 'terraFarmSettings.xml'
+    local xmlFile = ModUtils.createSavegameDirectoryXMLFile('modSettings', 'terraFarmSettings.xml', 'settings')
+
+    if xmlFile == nil then
+        Logging.error('Could not create TerraFarm settings file "%s"', filename)
+        return false
+    end
+
+    xmlFile:setBool('settings.enabled', self.enabled)
+    xmlFile:setBool('settings.defaultEnabled', self.defaultEnabled)
+    xmlFile:setBool('settings.resourcesActive', g_resourceManager.active)
+
+    self:saveMaterialSettings(xmlFile)
+
+    local success = xmlFile:save() == true
+    xmlFile:delete()
+
+    if not success then
+        Logging.error('Could not write TerraFarm settings file "%s"', filename)
+    end
+
+    return success
 end
 
 function ModSettings:loadUserSettings()

--- a/scripts/extensions/SavegameControllerExtension.lua
+++ b/scripts/extensions/SavegameControllerExtension.lua
@@ -1,7 +1,19 @@
+local function saveTerraFarmFile(filename, callback)
+    local success, errorMessage = pcall(callback)
+
+    if not success then
+        local absFilename = ModUtils.getSavegameDirectoryFilename(filename) or filename
+        Logging.error('Could not save TerraFarm data to "%s": %s', absFilename, tostring(errorMessage))
+    end
+end
+
 local function post_SavegameController_onSaveComplete(self, errorCode)
     if errorCode == Savegame.ERROR_OK and g_modSettings ~= nil then
-        pcall(function ()
+        saveTerraFarmFile('terraFarmSettings.xml', function ()
             g_modSettings:saveSettings()
+        end)
+
+        saveTerraFarmFile('terraFarmAreas.xml', function ()
             g_landscapingManager:saveAreasToXML()
         end)
     end

--- a/scripts/landscaping/LandscapingManager.lua
+++ b/scripts/landscaping/LandscapingManager.lua
@@ -685,33 +685,44 @@ function LandscapingManager:loadAreasFromXML()
     end
 end
 
+---@return boolean
 function LandscapingManager:saveAreasToXML()
+    local filename = ModUtils.getSavegameDirectoryFilename('terraFarmAreas.xml') or 'terraFarmAreas.xml'
     local xmlFile = ModUtils.createSavegameDirectoryXMLFile('terraFarmAreas', 'terraFarmAreas.xml', 'areas', LandscapingArea.XML_SCHEMA)
 
-    if xmlFile ~= nil then
-        local i = 0
-
-        for _, area in pairs(self.areas) do
-            local key = string.format('areas.landscaping.area(%i)', i)
-
-            if area:saveToXMLFile(xmlFile, key) then
-                i = i + 1
-            end
-        end
-
-        i = 0
-
-        for _, waterplane in pairs(self.waterplanes) do
-            local key = string.format('areas.waterplanes.area(%i)', i)
-
-            if waterplane:saveToXMLFile(xmlFile, key) then
-                i = i + 1
-            end
-        end
-
-        xmlFile:save()
-        xmlFile:delete()
+    if xmlFile == nil then
+        Logging.error('Could not create TerraFarm landscaping file "%s"', filename)
+        return false
     end
+
+    local i = 0
+
+    for _, area in pairs(self.areas) do
+        local key = string.format('areas.landscaping.area(%i)', i)
+
+        if area:saveToXMLFile(xmlFile, key) then
+            i = i + 1
+        end
+    end
+
+    i = 0
+
+    for _, waterplane in pairs(self.waterplanes) do
+        local key = string.format('areas.waterplanes.area(%i)', i)
+
+        if waterplane:saveToXMLFile(xmlFile, key) then
+            i = i + 1
+        end
+    end
+
+    local success = xmlFile:save() == true
+    xmlFile:delete()
+
+    if not success then
+        Logging.error('Could not write TerraFarm landscaping file "%s"', filename)
+    end
+
+    return success
 end
 
 function LandscapingManager:onPostTerrainInit()

--- a/tests/test_save_error_handling.lua
+++ b/tests/test_save_error_handling.lua
@@ -1,0 +1,222 @@
+local testFilename = debug.getinfo(1, 'S').source:sub(2)
+local projectDirectory = testFilename:match('^(.*)/tests/[^/]+$')
+
+if projectDirectory == nil and testFilename:match('^tests/[^/]+$') then
+    projectDirectory = '.'
+end
+
+if projectDirectory == nil then
+    error('Run this test from a file inside the tests directory.')
+end
+
+local function loadProjectFile(filename)
+    local path = projectDirectory .. '/' .. filename
+    local file = assert(io.open(path, 'r'))
+    local contents = file:read('*a')
+    file:close()
+
+    contents = contents:gsub(
+        '([%w_%.%[%]]+)%s*([%+%-%*/])=%s*([^\r\n]+)',
+        function (name, operator, value)
+            return string.format('%s = %s %s %s', name, name, operator, value)
+        end
+    )
+    contents = contents:gsub('([ \t]*)continue([ \t]*)(\r?\n)', '%1-- continue%2%3')
+    contents = contents:gsub('\ng_modSettings = ModSettings%.new%(%)[\r\n]*$', '\n')
+    contents = contents:gsub('\ng_landscapingManager = LandscapingManager%.new%(%)\r?\ng_landscapingManager:loadShapes%(%)[\r\n]*$', '\n')
+
+    assert(load(contents, '@' .. path))()
+end
+
+local function assertEqual(actual, expected, message)
+    if actual ~= expected then
+        error(string.format('%s: expected %s, got %s', message, tostring(expected), tostring(actual)), 2)
+    end
+end
+
+local originalSaveCalls = 0
+local logEntries = {}
+
+local function assertLogContains(pattern, message)
+    for _, entry in ipairs(logEntries) do
+        if entry:find(pattern, 1, true) ~= nil then
+            return
+        end
+    end
+
+    error(message .. ': ' .. table.concat(logEntries, ' | '), 2)
+end
+
+g_modDirectory = projectDirectory .. '/'
+g_modDirectorySettings = '/user/'
+g_currentMission = {
+    missionInfo = {
+        savegameDirectory = '/savegame1',
+    }
+}
+g_resourceManager = {
+    active = true,
+}
+g_server = {}
+
+function source()
+end
+
+function Class(class)
+    return {
+        __index = class,
+    }
+end
+
+Logging = {
+    error = function (formatString, ...)
+        table.insert(logEntries, string.format(formatString, ...))
+    end,
+}
+
+LandscapingArea = {
+    XML_SCHEMA = {},
+    createXMLSchema = function ()
+    end,
+}
+
+Savegame = {
+    ERROR_OK = 0,
+}
+
+SavegameController = {
+    onSaveComplete = function ()
+        originalSaveCalls = originalSaveCalls + 1
+        return 'originalResult'
+    end,
+}
+
+Utils = {
+    appendedFunction = function (originalFunction, appendedFunction)
+        return function (...)
+            local results = { originalFunction(...) }
+            appendedFunction(...)
+            return table.unpack(results)
+        end
+    end,
+}
+
+XMLFile = {}
+
+loadProjectFile('scripts/ModUtils.lua')
+loadProjectFile('scripts/ModSettings.lua')
+loadProjectFile('scripts/landscaping/LandscapingManager.lua')
+loadProjectFile('scripts/extensions/SavegameControllerExtension.lua')
+
+local settingsSaveCalls = 0
+local areaSaveCalls = 0
+
+g_modSettings = {
+    saveSettings = function ()
+        settingsSaveCalls = settingsSaveCalls + 1
+        error('settings exploded')
+    end,
+}
+g_landscapingManager = {
+    saveAreasToXML = function ()
+        areaSaveCalls = areaSaveCalls + 1
+    end,
+}
+
+local originalResult = SavegameController:onSaveComplete(Savegame.ERROR_OK)
+
+assertEqual(originalResult, 'originalResult', 'Save callback return value changed')
+assertEqual(originalSaveCalls, 1, 'Original save callback was not called')
+assertEqual(settingsSaveCalls, 1, 'Settings save was not attempted')
+assertEqual(areaSaveCalls, 1, 'Settings failure prevented the landscaping save')
+assertLogContains('/savegame1/terraFarmSettings.xml', 'Settings exception did not include its save path')
+assertLogContains('settings exploded', 'Settings exception was not logged')
+
+logEntries = {}
+g_modSettings.saveSettings = function ()
+    settingsSaveCalls = settingsSaveCalls + 1
+end
+g_landscapingManager.saveAreasToXML = function ()
+    areaSaveCalls = areaSaveCalls + 1
+    error('areas exploded')
+end
+
+SavegameController:onSaveComplete(Savegame.ERROR_OK)
+
+assertLogContains('/savegame1/terraFarmAreas.xml', 'Landscaping exception did not include its save path')
+assertLogContains('areas exploded', 'Landscaping exception was not logged')
+
+local callsBeforeFailedBaseSave = settingsSaveCalls + areaSaveCalls
+SavegameController:onSaveComplete(1)
+assertEqual(settingsSaveCalls + areaSaveCalls, callsBeforeFailedBaseSave, 'TerraFarm data was saved after the base save failed')
+
+local function makeXMLFile(saveResult)
+    return {
+        deleteCount = 0,
+        setBool = function ()
+        end,
+        setString = function ()
+        end,
+        setValue = function ()
+        end,
+        save = function ()
+            return saveResult
+        end,
+        delete = function (self)
+            self.deleteCount = self.deleteCount + 1
+        end,
+    }
+end
+
+local settings = setmetatable({
+    enabled = true,
+    defaultEnabled = true,
+    materials = {},
+}, {
+    __index = ModSettings,
+})
+
+logEntries = {}
+XMLFile.create = function ()
+    return nil
+end
+
+assertEqual(settings:saveSettings(), false, 'Settings XML creation failure was not returned')
+assertLogContains('/savegame1/terraFarmSettings.xml', 'Settings XML creation failure did not include its save path')
+
+logEntries = {}
+local settingsXMLFile = makeXMLFile(false)
+XMLFile.create = function ()
+    return settingsXMLFile
+end
+
+assertEqual(settings:saveSettings(), false, 'Settings XML write failure was not returned')
+assertEqual(settingsXMLFile.deleteCount, 1, 'Settings XML file was not released after a write failure')
+assertLogContains('/savegame1/terraFarmSettings.xml', 'Settings XML write failure did not include its save path')
+
+logEntries = {}
+local areasManager = setmetatable({
+    areas = {},
+    waterplanes = {},
+}, {
+    __index = LandscapingManager,
+})
+
+XMLFile.create = function ()
+    return nil
+end
+
+assertEqual(areasManager:saveAreasToXML(), false, 'Landscaping XML creation failure was not returned')
+assertLogContains('/savegame1/terraFarmAreas.xml', 'Landscaping XML creation failure did not include its save path')
+
+logEntries = {}
+local areasXMLFile = makeXMLFile(false)
+XMLFile.create = function ()
+    return areasXMLFile
+end
+
+assertEqual(areasManager:saveAreasToXML(), false, 'Landscaping XML write failure was not returned')
+assertEqual(areasXMLFile.deleteCount, 1, 'Landscaping XML file was not released after a write failure')
+assertLogContains('/savegame1/terraFarmAreas.xml', 'Landscaping XML write failure did not include its save path')
+
+print('All save error handling checks passed.')


### PR DESCRIPTION
TerraFarm currently saves its settings and landscaping data inside one protected call. If the settings save fails, the landscaping data is skipped, and the error is discarded without identifying the affected file.

This change runs the two saves independently and reports exceptions with the destination path. It also checks XML creation and write results so ordinary file failures are no longer silent.

Tested with focused save-failure coverage, Lua syntax and package checks, and an FS25 1.21 dedicated-server startup.
